### PR TITLE
fix: changed action type in memory env

### DIFF
--- a/src/xminigrid/envs/minigrid/memory.py
+++ b/src/xminigrid/envs/minigrid/memory.py
@@ -110,7 +110,7 @@ class Memory(Environment[EnvParams, MemoryEnvCarry]):
         self, params: EnvParams, timestep: TimeStep[MemoryEnvCarry], action: IntOrArray
     ) -> TimeStep[MemoryEnvCarry]:
         # disabling pick_up action
-        action = jax.lax.select(jnp.equal(action, 3), jnp.asarray(5, dtype=jnp.uint8), action)
+        action = jax.lax.select(jnp.equal(action, 3), jnp.asarray(5, dtype=jnp.int32), action)
         new_grid, new_agent, _ = take_action(timestep.state.grid, timestep.state.agent, action)
 
         new_state = timestep.state.replace(grid=new_grid, agent=new_agent, step_num=timestep.state.step_num + 1)


### PR DESCRIPTION
Description:
This pull request addresses an issue where a type mismatch occurs in `lax.select` within the minigrid/memory.py file. The mismatch is between `int32` and `uint8` types. This fix ensures that both arguments to `lax.select` are of the same type (int32), preventing the TypeError.